### PR TITLE
fix README.md config error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,3 @@ install && composer run-script parse-stubs` after.
 For auto-completion popup, you might need to install
 [nvim-completion-manager](https://github.com/roxma/nvim-completion-manager).
 
-## Config
-
-```vim
-autocmd FileType php LanguageClientStart
-```
-


### PR DESCRIPTION
related issue: https://github.com/autozimu/LanguageClient-neovim/issues/330

according to the doc(https://github.com/autozimu/LanguageClient-neovim/blob/next/doc/LanguageClient.txt#L112) ,  `g:LanguageClient_autoStart` was set to 1 by default. so we did not need
`autocmd FileType php LanguageClientStart` anymore. 

`autocmd FileType php LanguageClientStart` caused the err msg:
`Language server (xxx) exited unexpectedly! `

the reason it the the filetype autocmd config seems to be in conflict with   `g:LanguageClient_autoStart`
 (https://github.com/autozimu/LanguageClient-neovim/blob/next/doc/LanguageClient.txt#L112) which set to 1 by default.